### PR TITLE
refactor(rule): rename unused parameter in english plural rules to in…

### DIFF
--- a/src/infrastructure/rule/english-rules.service.ts
+++ b/src/infrastructure/rule/english-rules.service.ts
@@ -71,7 +71,7 @@ export const englishPluralRules: Array<IRule> = [
 	// Default rule: add s
 	{
 		apply: (word: string): string => `${word}s`,
-		matches: (word: string): boolean => true,
+		matches: (_word: string): boolean => true,
 	},
 ];
 


### PR DESCRIPTION
…dicate it's unused

Changed the parameter name 'word' to '_word' in the default plural rule's matches function to follow the convention of prefixing unused parameters with an underscore. This helps clarify that the parameter is not being used within the function.