### PR TITLE
chore(deps): update eslint-config dependency to version 3.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"@commitlint/cli": "^19.8.0",
 		"@commitlint/config-conventional": "^19.8.0",
 		"@elsikora/commitizen-plugin-commitlint-ai": "^1.0.0",
-		"@elsikora/eslint-config": "^3.7.6",
+		"@elsikora/eslint-config": "^3.7.7",
 		"@rollup/plugin-typescript": "^12.1.2",
 		"@saithodev/semantic-release-backmerge": "^4.0.1",
 		"@semantic-release/changelog": "^6.0.3",


### PR DESCRIPTION
Updated @elsikora/eslint-config package from version 3.7.6 to 3.7.7 to ensure the project uses the latest linting rules and configurations.