### PR TITLE
build(package): fix package.json exports and add sourcemaps

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,7 +3,7 @@ export default {
 		const commands = [];
 		commands.push("prettier --write --ignore-unknown");
 
-		const filteredFiles = files.filter((file) => !file.includes("test/") && !file.includes("vitest") && !file.includes("CHANGELOG"));
+		const filteredFiles = files.filter((file) => !file.includes("test/") && !file.includes("tsconfig") && !file.includes("vitest") && !file.includes("CHANGELOG"));
 
 		const eslintFiles = filteredFiles.filter((fileName) => {
 			const validExtensions = ["js", "jsx", "mjs", "cjs", "ts", "tsx", "json", "jsonc", "yml", "yaml"];

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
 	"name": "@elsikora/pluralizer",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "A library for pluralizing words in different languages",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
 	"exports": {
 		".": {
-			"import": "./dist/esm/index.js",
-			"require": "./dist/cjs/index.js"
+			"require": "./dist/cjs/index.js",
+			"import": "./dist/esm/index.js"
 		}
 	},
 	"files": [
-		"./dist"
+		"dist"
 	],
 	"scripts": {
 		"prebuild": "rimraf dist",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,12 +10,14 @@ export default [
 			dir: "dist/esm",
 			format: "esm",
 			preserveModules: true,
+			sourcemap: true,
 		},
 		plugins: [
 			typescript({
 				declaration: true,
 				declarationDir: "dist/esm",
 				outDir: "dist/esm",
+				sourceMap: true,
 				tsconfig: "./tsconfig.build.json",
 			}),
 		],
@@ -28,12 +30,14 @@ export default [
 			exports: "named",
 			format: "cjs",
 			preserveModules: true,
+			sourcemap: true,
 		},
 		plugins: [
 			typescript({
 				declaration: true,
 				declarationDir: "dist/cjs",
 				outDir: "dist/cjs",
+				sourceMap: true,
 				tsconfig: "./tsconfig.build.json",
 			}),
 		],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "esModuleInterop": true,
-    "declaration": true,
-    "declarationDir": "dist/types",
-    "strict": true
-  },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "extends": "tsconfig.json",
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Updated package.json with correct main/module fields and fixed export paths. Added sourcemaps to both ESM and CJS builds. Fixed tsconfig reference and improved lint-staged configuration to exclude tsconfig files.