### PR TITLE
build(typescript): update typescript configuration to target esnext

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,13 @@
 {
-  "extends": "tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "strict": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Updated TypeScript configuration files to target ESNext instead of ES2020. Also restructured tsconfig.json to have its own direct configuration rather than extending another file.